### PR TITLE
fix: button display when star have two digits

### DIFF
--- a/src/build.mts
+++ b/src/build.mts
@@ -24,7 +24,7 @@ function githubBtn(
     authorName,
   )}&repo=${querystring.escape(repoName)}&type=star&count=true${
     large && '&size=large'
-  }" frameborder="0" scrolling="0" width="115" height="32" title="GitHub">
+  }" frameborder="0" scrolling="0" width="140" height="32" title="GitHub">
   </iframe>`
 }
 


### PR DESCRIPTION
When a star has one digit, the website will displays it, but when the star has two digits, because the GitHub button's weight is too small, it cannot be accuratly displayed.

Before Fix:

![image](https://github.com/user-attachments/assets/d91d8385-b407-46be-bc4e-728252651cd3)

After Fix:

![image](https://github.com/user-attachments/assets/b2b850c2-6db3-4c66-bcef-d5c0c215d162)

